### PR TITLE
 Verify the key is not null

### DIFF
--- a/07-Set-and-Map/06-LinkedListMap/src/LinkedListMap.java
+++ b/07-Set-and-Map/06-LinkedListMap/src/LinkedListMap.java
@@ -68,6 +68,9 @@ public class LinkedListMap<K, V> implements Map<K, V> {
 
     @Override
     public void add(K key, V value){
+        if (key == null) {
+            throw new IllegalArgumentException("key can't be null!");
+        }
         Node node = getNode(key);
         if(node == null){
             dummyHead.next = new Node(key, value, dummyHead.next);

--- a/07-Set-and-Map/06-LinkedListMap/src/LinkedListMap.java
+++ b/07-Set-and-Map/06-LinkedListMap/src/LinkedListMap.java
@@ -68,9 +68,9 @@ public class LinkedListMap<K, V> implements Map<K, V> {
 
     @Override
     public void add(K key, V value){
-        if (key == null) {
+        if (key == null)
             throw new IllegalArgumentException("key can't be null!");
-        }
+      
         Node node = getNode(key);
         if(node == null){
             dummyHead.next = new Node(key, value, dummyHead.next);

--- a/07-Set-and-Map/07-BSTMap/src/BSTMap.java
+++ b/07-Set-and-Map/07-BSTMap/src/BSTMap.java
@@ -36,6 +36,9 @@ public class BSTMap<K extends Comparable<K>, V> implements Map<K, V> {
     // 向二分搜索树中添加新的元素(key, value)
     @Override
     public void add(K key, V value){
+        if (key == null) {
+            throw new IllegalArgumentException("key can't be null!");
+        }
         root = add(root, key, value);
     }
 

--- a/07-Set-and-Map/07-BSTMap/src/BSTMap.java
+++ b/07-Set-and-Map/07-BSTMap/src/BSTMap.java
@@ -36,9 +36,9 @@ public class BSTMap<K extends Comparable<K>, V> implements Map<K, V> {
     // 向二分搜索树中添加新的元素(key, value)
     @Override
     public void add(K key, V value){
-        if (key == null) {
+        if (key == null)
             throw new IllegalArgumentException("key can't be null!");
-        }
+        
         root = add(root, key, value);
     }
 
@@ -63,6 +63,9 @@ public class BSTMap<K extends Comparable<K>, V> implements Map<K, V> {
 
     // 返回以node为根节点的二分搜索树中，key所在的节点
     private Node getNode(Node node, K key){
+
+        if (key == null)
+            throw new IllegalArgumentException("key can't be null!");
 
         if(node == null)
             return null;


### PR DESCRIPTION
在map 集合中,是否应该对key为null做个校验,增强程序健壮性,否则在BSTMap中,如果不对key为null做校验的话.在add方法的key.compareTo()方法会抛出NullPointerException